### PR TITLE
slurm-web: fix python3-markdown dependency

### DIFF
--- a/slurm-web/artifact.yml
+++ b/slurm-web/artifact.yml
@@ -9,6 +9,6 @@ derivatives:
   slurmweb-5: 5.0.0
   slurmweb-4: 4.2.0
 rpm:
-  release: 2
+  release: 3
 deb:
-  release: 2
+  release: 3

--- a/slurm-web/deb/control.j2
+++ b/slurm-web/deb/control.j2
@@ -52,6 +52,7 @@ Depends:
  ${python3:Depends},
  python3-slurm-web (= ${binary:Version}),
 {% if version.major | int > 3 %}
+ python3-markdown,
  python3-aiohttp,
 {% endif %}
  acl,
@@ -69,7 +70,6 @@ Depends:
  ${python3:Depends},
  python3-slurm-web (= ${binary:Version}),
 {% if version.major | int > 3 %}
- python3-markdown,
  python3-prometheus-client,
 {% endif %}
  python3-racksdb-web,


### PR DESCRIPTION
Closes https://github.com/rackslab/Slurm-web/issues/596.